### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 
+## [0.3.0](https://github.com/torchbox/eslint-config-torchbox/compare/v0.2.0...v0.3.0) (2019-10-08)
+
 ### Features
 
-- Update to ESLint v6 and eslint-config-airbnb v18, significantly changing rules that are applied with this config ([#4](https://github.com/torchbox/eslint-config-torchbox/issues/4)).
-- Include rules for the React [Rules of hooks](https://reactjs.org/docs/hooks-rules.html) ([#3](https://github.com/torchbox/eslint-config-torchbox/issues/3)), from the airbnb config update.
-- Automatically detect which version of React is being used on the project to lint accordingly (part of the airbnb config update).
+- Update to ESLint v6 and eslint-config-airbnb v18, significantly changing rules that are applied with this config ([#4](https://github.com/torchbox/eslint-config-torchbox/issues/4), [#10](https://github.com/torchbox/eslint-config-torchbox/pull/10)).
+- Include rules for the React [Rules of hooks](https://reactjs.org/docs/hooks-rules.html) ([#3](https://github.com/torchbox/eslint-config-torchbox/issues/3), [#10](https://github.com/torchbox/eslint-config-torchbox/pull/10)), from the airbnb config update.
+- Automatically detect which version of React is being used on the project to lint accordingly (part of the airbnb config update) ([#10](https://github.com/torchbox/eslint-config-torchbox/pull/10)).
 
 ### BREAKING CHANGES
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module.exports = {
 
 - [no-param-reassign](https://eslint.org/docs/rules/no-param-reassign): `2, props: false`
 - [no-warning-comments](https://eslint.org/docs/rules/no-warning-comments): `1, terms: todo, fixme, xxx, location: start`
-- [no-underscore-dangle](https://eslint.org/docs/rules/no-underscore-dangle): `2, allow: __REDUX_DEVTOOLS_EXTENSION__, __webpack_hash__`
+- [no-underscore-dangle](https://eslint.org/docs/rules/no-underscore-dangle): `2, allow: __REDUX_DEVTOOLS_EXTENSION__, __webpack_hash__, al…`
 - [camelcase](https://eslint.org/docs/rules/camelcase): `0`
 - [no-console](https://eslint.org/docs/rules/no-console): `2, allow: error`
 - [react/forbid-prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md): `2, forbid: any`
@@ -80,156 +80,40 @@ module.exports = {
 
 ### Inherited rules
 
-- [array-callback-return](https://eslint.org/docs/rules/array-callback-return): `error, allowImplicit: true`
-- [block-scoped-var](https://eslint.org/docs/rules/block-scoped-var)
+- [jsx-a11y/anchor-has-content](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md): `error, components:`
+- [jsx-a11y/aria-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md): `error, ignoreNonDom: false, ignoreNonDOM: false`
+- [jsx-a11y/aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md)
+- [jsx-a11y/aria-proptypes](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md)
+- [jsx-a11y/aria-unsupported-elements](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md)
+- [jsx-a11y/alt-text](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md): `error, elements: img, object, area, inputtype=\image\, img: …`
+- [jsx-a11y/img-redundant-alt](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md)
+- [jsx-a11y/label-has-associated-control](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md): `error, labelComponents: , labelAttributes: , controlComponen…`
+- [jsx-a11y/control-has-associated-label](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/control-has-associated-label.md): `error, labelAttributes: label, controlComponents: , ignoreEl…`
+- [jsx-a11y/mouse-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md)
+- [jsx-a11y/no-access-key](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md)
+- [jsx-a11y/interactive-supports-focus](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md)
+- [jsx-a11y/role-has-required-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md)
+- [jsx-a11y/role-supports-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md)
+- [jsx-a11y/tabindex-no-positive](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md)
+- [jsx-a11y/heading-has-content](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md): `error, components:`
+- [jsx-a11y/html-has-lang](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/html-has-lang.md)
+- [jsx-a11y/lang](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md)
+- [jsx-a11y/no-distracting-elements](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md): `error, elements: marquee, blink`
+- [jsx-a11y/scope](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md)
+- [jsx-a11y/click-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md)
+- [jsx-a11y/no-static-element-interactions](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md): `error, handlers: onClick, onMouseDown, onMouseUp, onKeyPress…`
+- [jsx-a11y/no-noninteractive-element-interactions](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md): `error, handlers: onClick, onMouseDown, onMouseUp, onKeyPress…`
+- [jsx-a11y/accessible-emoji](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
+- [jsx-a11y/aria-activedescendant-has-tabindex](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md)
+- [jsx-a11y/iframe-has-title](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md)
+- [jsx-a11y/no-autofocus](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md): `error, ignoreNonDOM: true`
+- [jsx-a11y/no-redundant-roles](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md)
+- [jsx-a11y/media-has-caption](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md): `error, audio: , video: , track:`
+- [jsx-a11y/no-interactive-element-to-noninteractive-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md): `error, tr: none, presentation`
+- [jsx-a11y/no-noninteractive-element-to-interactive-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md): `error, ul: listbox, menu, menubar, radiogroup, tablist, tree…`
+- [jsx-a11y/no-noninteractive-tabindex](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-tabindex.md): `error, tags: , roles: tabpanel`
+- [jsx-a11y/anchor-is-valid](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md): `error, components: Link, specialLink: to, aspects: noHref, i…`
 - [class-methods-use-this](https://eslint.org/docs/rules/class-methods-use-this): `error, exceptMethods: render, getInitialState, getDefaultPro…`
-- [consistent-return](https://eslint.org/docs/rules/consistent-return)
-- [default-case](https://eslint.org/docs/rules/default-case): `error, commentPattern: ^no default$`
-- [dot-notation](https://eslint.org/docs/rules/dot-notation): `error, allowKeywords: true`
-- [eqeqeq](https://eslint.org/docs/rules/eqeqeq): `error, always, null: ignore`
-- [guard-for-in](https://eslint.org/docs/rules/guard-for-in)
-- [no-alert](https://eslint.org/docs/rules/no-alert): `warn`
-- [no-caller](https://eslint.org/docs/rules/no-caller)
-- [no-case-declarations](https://eslint.org/docs/rules/no-case-declarations)
-- [no-else-return](https://eslint.org/docs/rules/no-else-return): `error, allowElseIf: false`
-- [no-empty-function](https://eslint.org/docs/rules/no-empty-function): `error, allow: arrowFunctions, functions, methods`
-- [no-empty-pattern](https://eslint.org/docs/rules/no-empty-pattern)
-- [no-eval](https://eslint.org/docs/rules/no-eval)
-- [no-extend-native](https://eslint.org/docs/rules/no-extend-native)
-- [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind)
-- [no-extra-label](https://eslint.org/docs/rules/no-extra-label)
-- [no-fallthrough](https://eslint.org/docs/rules/no-fallthrough)
-- [no-global-assign](https://eslint.org/docs/rules/no-global-assign): `error, exceptions:`
-- [no-implied-eval](https://eslint.org/docs/rules/no-implied-eval)
-- [no-iterator](https://eslint.org/docs/rules/no-iterator)
-- [no-labels](https://eslint.org/docs/rules/no-labels): `error, allowLoop: false, allowSwitch: false`
-- [no-lone-blocks](https://eslint.org/docs/rules/no-lone-blocks)
-- [no-loop-func](https://eslint.org/docs/rules/no-loop-func)
-- [no-multi-str](https://eslint.org/docs/rules/no-multi-str)
-- [no-new](https://eslint.org/docs/rules/no-new)
-- [no-new-func](https://eslint.org/docs/rules/no-new-func)
-- [no-new-wrappers](https://eslint.org/docs/rules/no-new-wrappers)
-- [no-octal](https://eslint.org/docs/rules/no-octal)
-- [no-octal-escape](https://eslint.org/docs/rules/no-octal-escape)
-- [no-proto](https://eslint.org/docs/rules/no-proto)
-- [no-redeclare](https://eslint.org/docs/rules/no-redeclare)
-- [no-restricted-properties](https://eslint.org/docs/rules/no-restricted-properties): `error, object: arguments, property: callee, message: argumen…`
-- [no-return-assign](https://eslint.org/docs/rules/no-return-assign): `error, always`
-- [no-return-await](https://eslint.org/docs/rules/no-return-await)
-- [no-script-url](https://eslint.org/docs/rules/no-script-url)
-- [no-self-assign](https://eslint.org/docs/rules/no-self-assign): `error, props: false`
-- [no-self-compare](https://eslint.org/docs/rules/no-self-compare)
-- [no-sequences](https://eslint.org/docs/rules/no-sequences)
-- [no-throw-literal](https://eslint.org/docs/rules/no-throw-literal)
-- [no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions): `error, allowShortCircuit: false, allowTernary: false, allowT…`
-- [no-unused-labels](https://eslint.org/docs/rules/no-unused-labels)
-- [no-useless-concat](https://eslint.org/docs/rules/no-useless-concat)
-- [no-useless-escape](https://eslint.org/docs/rules/no-useless-escape)
-- [no-useless-return](https://eslint.org/docs/rules/no-useless-return)
-- [no-void](https://eslint.org/docs/rules/no-void)
-- [no-with](https://eslint.org/docs/rules/no-with)
-- [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors): `error, allowEmptyReject: true`
-- [radix](https://eslint.org/docs/rules/radix)
-- [vars-on-top](https://eslint.org/docs/rules/vars-on-top)
-- [yoda](https://eslint.org/docs/rules/yoda)
-- [for-direction](https://eslint.org/docs/rules/for-direction)
-- [getter-return](https://eslint.org/docs/rules/getter-return): `error, allowImplicit: true`
-- [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop)
-- [no-compare-neg-zero](https://eslint.org/docs/rules/no-compare-neg-zero)
-- [no-cond-assign](https://eslint.org/docs/rules/no-cond-assign): `error, always`
-- [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition): `warn`
-- [no-control-regex](https://eslint.org/docs/rules/no-control-regex)
-- [no-debugger](https://eslint.org/docs/rules/no-debugger)
-- [no-dupe-args](https://eslint.org/docs/rules/no-dupe-args)
-- [no-dupe-keys](https://eslint.org/docs/rules/no-dupe-keys)
-- [no-duplicate-case](https://eslint.org/docs/rules/no-duplicate-case)
-- [no-empty](https://eslint.org/docs/rules/no-empty)
-- [no-empty-character-class](https://eslint.org/docs/rules/no-empty-character-class)
-- [no-ex-assign](https://eslint.org/docs/rules/no-ex-assign)
-- [no-extra-boolean-cast](https://eslint.org/docs/rules/no-extra-boolean-cast)
-- [no-func-assign](https://eslint.org/docs/rules/no-func-assign)
-- [no-inner-declarations](https://eslint.org/docs/rules/no-inner-declarations)
-- [no-invalid-regexp](https://eslint.org/docs/rules/no-invalid-regexp)
-- [no-irregular-whitespace](https://eslint.org/docs/rules/no-irregular-whitespace)
-- [no-obj-calls](https://eslint.org/docs/rules/no-obj-calls)
-- [no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins)
-- [no-regex-spaces](https://eslint.org/docs/rules/no-regex-spaces)
-- [no-sparse-arrays](https://eslint.org/docs/rules/no-sparse-arrays)
-- [no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)
-- [no-unreachable](https://eslint.org/docs/rules/no-unreachable)
-- [no-unsafe-finally](https://eslint.org/docs/rules/no-unsafe-finally)
-- [no-unsafe-negation](https://eslint.org/docs/rules/no-unsafe-negation)
-- [use-isnan](https://eslint.org/docs/rules/use-isnan)
-- [valid-typeof](https://eslint.org/docs/rules/valid-typeof): `error, requireStringLiterals: true`
-- [global-require](https://eslint.org/docs/rules/global-require)
-- [no-buffer-constructor](https://eslint.org/docs/rules/no-buffer-constructor)
-- [no-new-require](https://eslint.org/docs/rules/no-new-require)
-- [no-path-concat](https://eslint.org/docs/rules/no-path-concat)
-- [func-names](https://eslint.org/docs/rules/func-names): `warn`
-- [lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members): `error, always, exceptAfterSingleLine: false`
-- [lines-around-directive](https://eslint.org/docs/rules/lines-around-directive): `error, before: always, after: always`
-- [new-cap](https://eslint.org/docs/rules/new-cap): `error, newIsCap: true, newIsCapExceptions: , capIsNew: false…`
-- [no-array-constructor](https://eslint.org/docs/rules/no-array-constructor)
-- [no-bitwise](https://eslint.org/docs/rules/no-bitwise)
-- [no-continue](https://eslint.org/docs/rules/no-continue)
-- [no-lonely-if](https://eslint.org/docs/rules/no-lonely-if)
-- [no-multi-assign](https://eslint.org/docs/rules/no-multi-assign)
-- [no-nested-ternary](https://eslint.org/docs/rules/no-nested-ternary)
-- [no-new-object](https://eslint.org/docs/rules/no-new-object)
-- [no-plusplus](https://eslint.org/docs/rules/no-plusplus)
-- [no-restricted-syntax](https://eslint.org/docs/rules/no-restricted-syntax): `error, selector: ForInStatement, message: for..in loops iter…`
-- [no-unneeded-ternary](https://eslint.org/docs/rules/no-unneeded-ternary): `error, defaultAssignment: false`
-- [one-var](https://eslint.org/docs/rules/one-var): `error, never`
-- [operator-assignment](https://eslint.org/docs/rules/operator-assignment): `error, always`
-- [spaced-comment](https://eslint.org/docs/rules/spaced-comment): `error, always, line: exceptions: -, +, markers: =, !, block:…`
-- [no-delete-var](https://eslint.org/docs/rules/no-delete-var)
-- [no-label-var](https://eslint.org/docs/rules/no-label-var)
-- [no-restricted-globals](https://eslint.org/docs/rules/no-restricted-globals): `error, isFinite, isNaN, addEventListener, blur, close, close…`
-- [no-shadow](https://eslint.org/docs/rules/no-shadow)
-- [no-shadow-restricted-names](https://eslint.org/docs/rules/no-shadow-restricted-names)
-- [no-undef](https://eslint.org/docs/rules/no-undef)
-- [no-undef-init](https://eslint.org/docs/rules/no-undef-init)
-- [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars): `error, vars: all, args: after-used, ignoreRestSiblings: true`
-- [no-use-before-define](https://eslint.org/docs/rules/no-use-before-define): `error, functions: true, classes: true, variables: true`
-- [constructor-super](https://eslint.org/docs/rules/constructor-super)
-- [no-class-assign](https://eslint.org/docs/rules/no-class-assign)
-- [no-const-assign](https://eslint.org/docs/rules/no-const-assign)
-- [no-dupe-class-members](https://eslint.org/docs/rules/no-dupe-class-members)
-- [no-new-symbol](https://eslint.org/docs/rules/no-new-symbol)
-- [no-this-before-super](https://eslint.org/docs/rules/no-this-before-super)
-- [no-useless-computed-key](https://eslint.org/docs/rules/no-useless-computed-key)
-- [no-useless-constructor](https://eslint.org/docs/rules/no-useless-constructor)
-- [no-useless-rename](https://eslint.org/docs/rules/no-useless-rename): `error, ignoreDestructuring: false, ignoreImport: false, igno…`
-- [no-var](https://eslint.org/docs/rules/no-var)
-- [object-shorthand](https://eslint.org/docs/rules/object-shorthand): `error, always, ignoreConstructors: false, avoidQuotes: true`
-- [prefer-const](https://eslint.org/docs/rules/prefer-const): `error, destructuring: any, ignoreReadBeforeAssign: true`
-- [prefer-destructuring](https://eslint.org/docs/rules/prefer-destructuring): `error, VariableDeclarator: array: false, object: true, Assig…`
-- [prefer-numeric-literals](https://eslint.org/docs/rules/prefer-numeric-literals)
-- [prefer-rest-params](https://eslint.org/docs/rules/prefer-rest-params)
-- [prefer-spread](https://eslint.org/docs/rules/prefer-spread)
-- [prefer-template](https://eslint.org/docs/rules/prefer-template)
-- [require-yield](https://eslint.org/docs/rules/require-yield)
-- [symbol-description](https://eslint.org/docs/rules/symbol-description)
-- [import/no-unresolved](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md): `error, commonjs: true, caseSensitive: true`
-- [import/named](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md)
-- [import/export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md)
-- [import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md)
-- [import/no-named-as-default-member](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md)
-- [import/no-mutable-exports](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md)
-- [import/no-amd](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md)
-- [import/first](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)
-- [import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)
-- [import/extensions](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md): `error, ignorePackages, js: never, mjs: never, jsx: never`
-- [import/order](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md): `error, groups: builtin, external, internal`
-- [import/newline-after-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md)
-- [import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)
-- [import/no-dynamic-require](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md)
-- [import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)
-- [import/no-named-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md)
-- [import/no-self-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-self-import.md)
-- [import/no-cycle](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md): `error, maxDepth: null`
-- [import/no-useless-path-segments](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-useless-path-segments.md)
-- [strict](https://eslint.org/docs/rules/strict): `error, never`
 - [react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md): `error, never, always:`
 - [react/jsx-no-duplicate-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md): `error, ignoreCase: true`
 - [react/jsx-no-undef](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md)
@@ -272,39 +156,164 @@ module.exports = {
 - [react/no-access-state-in-setstate](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md)
 - [react/button-has-type](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/button-has-type.md): `error, button: true, submit: true, reset: false`
 - [react/no-this-in-sfc](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md)
-- [jsx-a11y/anchor-has-content](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md): `error, components:`
-- [jsx-a11y/aria-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md): `error, ignoreNonDom: false`
-- [jsx-a11y/aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md)
-- [jsx-a11y/aria-proptypes](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md)
-- [jsx-a11y/aria-unsupported-elements](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md)
-- [jsx-a11y/alt-text](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md): `error, elements: img, object, area, inputtype=\image\, img: …`
-- [jsx-a11y/img-redundant-alt](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md)
-- [jsx-a11y/label-has-for](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md): `error, components: , required: every: nesting, id, allowChildren: false`
-- [jsx-a11y/label-has-associated-control](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md): `error, labelComponents: , labelAttributes: , controlComponen…`
-- [jsx-a11y/mouse-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md)
-- [jsx-a11y/no-access-key](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md)
-- [jsx-a11y/interactive-supports-focus](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md)
-- [jsx-a11y/role-has-required-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md)
-- [jsx-a11y/role-supports-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md)
-- [jsx-a11y/tabindex-no-positive](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md)
-- [jsx-a11y/heading-has-content](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md): `error, components:`
-- [jsx-a11y/html-has-lang](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/html-has-lang.md)
-- [jsx-a11y/lang](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md)
-- [jsx-a11y/no-distracting-elements](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md): `error, elements: marquee, blink`
-- [jsx-a11y/scope](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md)
-- [jsx-a11y/click-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md)
-- [jsx-a11y/no-static-element-interactions](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md): `error, handlers: onClick, onMouseDown, onMouseUp, onKeyPress…`
-- [jsx-a11y/no-noninteractive-element-interactions](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md): `error, handlers: onClick, onMouseDown, onMouseUp, onKeyPress…`
-- [jsx-a11y/accessible-emoji](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
-- [jsx-a11y/aria-activedescendant-has-tabindex](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md)
-- [jsx-a11y/iframe-has-title](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md)
-- [jsx-a11y/no-autofocus](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md): `error, ignoreNonDOM: true`
-- [jsx-a11y/no-redundant-roles](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md)
-- [jsx-a11y/media-has-caption](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md): `error, audio: , video: , track:`
-- [jsx-a11y/no-interactive-element-to-noninteractive-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md): `error, tr: none, presentation`
-- [jsx-a11y/no-noninteractive-element-to-interactive-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md): `error, ul: listbox, menu, menubar, radiogroup, tablist, tree…`
-- [jsx-a11y/no-noninteractive-tabindex](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-tabindex.md): `error, tags: , roles: tabpanel`
-- [jsx-a11y/anchor-is-valid](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md): `error, components: Link, specialLink: to, aspects: noHref, i…`
+- [react/jsx-fragments](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md): `error, syntax`
+- [react/state-in-constructor](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md): `error, always`
+- [react/static-property-placement](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md): `error, property assignment`
+- [react/jsx-props-no-spreading](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md): `error, html: enforce, custom: enforce, exceptions:`
+- [strict](https://eslint.org/docs/rules/strict): `error, never`
+- [import/no-unresolved](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md): `error, commonjs: true, caseSensitive: true`
+- [import/named](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md)
+- [import/export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md)
+- [import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md)
+- [import/no-named-as-default-member](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md)
+- [import/no-mutable-exports](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md)
+- [import/no-amd](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md)
+- [import/first](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)
+- [import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)
+- [import/extensions](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md): `error, ignorePackages, js: never, mjs: never, jsx: never`
+- [import/order](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md): `error, groups: builtin, external, internal`
+- [import/newline-after-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md)
+- [import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)
+- [import/no-dynamic-require](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md)
+- [import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)
+- [import/no-named-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md)
+- [import/no-self-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-self-import.md)
+- [import/no-cycle](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md): `error, maxDepth: null`
+- [import/no-useless-path-segments](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-useless-path-segments.md)
+- [constructor-super](https://eslint.org/docs/rules/constructor-super)
+- [no-class-assign](https://eslint.org/docs/rules/no-class-assign)
+- [no-const-assign](https://eslint.org/docs/rules/no-const-assign)
+- [no-dupe-class-members](https://eslint.org/docs/rules/no-dupe-class-members)
+- [no-new-symbol](https://eslint.org/docs/rules/no-new-symbol)
+- [no-this-before-super](https://eslint.org/docs/rules/no-this-before-super)
+- [no-useless-computed-key](https://eslint.org/docs/rules/no-useless-computed-key)
+- [no-useless-constructor](https://eslint.org/docs/rules/no-useless-constructor)
+- [no-useless-rename](https://eslint.org/docs/rules/no-useless-rename): `error, ignoreDestructuring: false, ignoreImport: false, igno…`
+- [no-var](https://eslint.org/docs/rules/no-var)
+- [object-shorthand](https://eslint.org/docs/rules/object-shorthand): `error, always, ignoreConstructors: false, avoidQuotes: true`
+- [prefer-const](https://eslint.org/docs/rules/prefer-const): `error, destructuring: any, ignoreReadBeforeAssign: true`
+- [prefer-destructuring](https://eslint.org/docs/rules/prefer-destructuring): `error, VariableDeclarator: array: false, object: true, Assig…`
+- [prefer-numeric-literals](https://eslint.org/docs/rules/prefer-numeric-literals)
+- [prefer-rest-params](https://eslint.org/docs/rules/prefer-rest-params)
+- [prefer-spread](https://eslint.org/docs/rules/prefer-spread)
+- [prefer-template](https://eslint.org/docs/rules/prefer-template)
+- [require-yield](https://eslint.org/docs/rules/require-yield)
+- [symbol-description](https://eslint.org/docs/rules/symbol-description)
+- [no-delete-var](https://eslint.org/docs/rules/no-delete-var)
+- [no-label-var](https://eslint.org/docs/rules/no-label-var)
+- [no-restricted-globals](https://eslint.org/docs/rules/no-restricted-globals): `error, isFinite, isNaN, addEventListener, blur, close, close…`
+- [no-shadow](https://eslint.org/docs/rules/no-shadow)
+- [no-shadow-restricted-names](https://eslint.org/docs/rules/no-shadow-restricted-names)
+- [no-undef](https://eslint.org/docs/rules/no-undef)
+- [no-undef-init](https://eslint.org/docs/rules/no-undef-init)
+- [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars): `error, vars: all, args: after-used, ignoreRestSiblings: true`
+- [no-use-before-define](https://eslint.org/docs/rules/no-use-before-define): `error, functions: true, classes: true, variables: true`
+- [func-names](https://eslint.org/docs/rules/func-names): `warn`
+- [lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members): `error, always, exceptAfterSingleLine: false`
+- [lines-around-directive](https://eslint.org/docs/rules/lines-around-directive): `error, before: always, after: always`
+- [new-cap](https://eslint.org/docs/rules/new-cap): `error, newIsCap: true, newIsCapExceptions: , capIsNew: false…`
+- [no-array-constructor](https://eslint.org/docs/rules/no-array-constructor)
+- [no-bitwise](https://eslint.org/docs/rules/no-bitwise)
+- [no-continue](https://eslint.org/docs/rules/no-continue)
+- [no-lonely-if](https://eslint.org/docs/rules/no-lonely-if)
+- [no-multi-assign](https://eslint.org/docs/rules/no-multi-assign)
+- [no-nested-ternary](https://eslint.org/docs/rules/no-nested-ternary)
+- [no-new-object](https://eslint.org/docs/rules/no-new-object)
+- [no-plusplus](https://eslint.org/docs/rules/no-plusplus)
+- [no-restricted-syntax](https://eslint.org/docs/rules/no-restricted-syntax): `error, selector: ForInStatement, message: for..in loops iter…`
+- [no-unneeded-ternary](https://eslint.org/docs/rules/no-unneeded-ternary): `error, defaultAssignment: false`
+- [one-var](https://eslint.org/docs/rules/one-var): `error, never`
+- [operator-assignment](https://eslint.org/docs/rules/operator-assignment): `error, always`
+- [prefer-object-spread](https://eslint.org/docs/rules/prefer-object-spread)
+- [spaced-comment](https://eslint.org/docs/rules/spaced-comment): `error, always, line: exceptions: -, +, markers: =, !, block:…`
+- [global-require](https://eslint.org/docs/rules/global-require)
+- [no-buffer-constructor](https://eslint.org/docs/rules/no-buffer-constructor)
+- [no-new-require](https://eslint.org/docs/rules/no-new-require)
+- [no-path-concat](https://eslint.org/docs/rules/no-path-concat)
+- [for-direction](https://eslint.org/docs/rules/for-direction)
+- [getter-return](https://eslint.org/docs/rules/getter-return): `error, allowImplicit: true`
+- [no-async-promise-executor](https://eslint.org/docs/rules/no-async-promise-executor)
+- [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop)
+- [no-compare-neg-zero](https://eslint.org/docs/rules/no-compare-neg-zero)
+- [no-cond-assign](https://eslint.org/docs/rules/no-cond-assign): `error, always`
+- [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition): `warn`
+- [no-control-regex](https://eslint.org/docs/rules/no-control-regex)
+- [no-debugger](https://eslint.org/docs/rules/no-debugger)
+- [no-dupe-args](https://eslint.org/docs/rules/no-dupe-args)
+- [no-dupe-keys](https://eslint.org/docs/rules/no-dupe-keys)
+- [no-duplicate-case](https://eslint.org/docs/rules/no-duplicate-case)
+- [no-empty](https://eslint.org/docs/rules/no-empty)
+- [no-empty-character-class](https://eslint.org/docs/rules/no-empty-character-class)
+- [no-ex-assign](https://eslint.org/docs/rules/no-ex-assign)
+- [no-extra-boolean-cast](https://eslint.org/docs/rules/no-extra-boolean-cast)
+- [no-func-assign](https://eslint.org/docs/rules/no-func-assign)
+- [no-inner-declarations](https://eslint.org/docs/rules/no-inner-declarations)
+- [no-invalid-regexp](https://eslint.org/docs/rules/no-invalid-regexp)
+- [no-irregular-whitespace](https://eslint.org/docs/rules/no-irregular-whitespace)
+- [no-misleading-character-class](https://eslint.org/docs/rules/no-misleading-character-class)
+- [no-obj-calls](https://eslint.org/docs/rules/no-obj-calls)
+- [no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins)
+- [no-regex-spaces](https://eslint.org/docs/rules/no-regex-spaces)
+- [no-sparse-arrays](https://eslint.org/docs/rules/no-sparse-arrays)
+- [no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)
+- [no-unreachable](https://eslint.org/docs/rules/no-unreachable)
+- [no-unsafe-finally](https://eslint.org/docs/rules/no-unsafe-finally)
+- [no-unsafe-negation](https://eslint.org/docs/rules/no-unsafe-negation)
+- [use-isnan](https://eslint.org/docs/rules/use-isnan)
+- [valid-typeof](https://eslint.org/docs/rules/valid-typeof): `error, requireStringLiterals: true`
+- [array-callback-return](https://eslint.org/docs/rules/array-callback-return): `error, allowImplicit: true`
+- [block-scoped-var](https://eslint.org/docs/rules/block-scoped-var)
+- [consistent-return](https://eslint.org/docs/rules/consistent-return)
+- [default-case](https://eslint.org/docs/rules/default-case): `error, commentPattern: ^no default$`
+- [dot-notation](https://eslint.org/docs/rules/dot-notation): `error, allowKeywords: true, allowPattern:`
+- [eqeqeq](https://eslint.org/docs/rules/eqeqeq): `error, always, null: ignore`
+- [guard-for-in](https://eslint.org/docs/rules/guard-for-in)
+- [max-classes-per-file](https://eslint.org/docs/rules/max-classes-per-file): `error, 1`
+- [no-alert](https://eslint.org/docs/rules/no-alert): `warn`
+- [no-caller](https://eslint.org/docs/rules/no-caller)
+- [no-case-declarations](https://eslint.org/docs/rules/no-case-declarations)
+- [no-else-return](https://eslint.org/docs/rules/no-else-return): `error, allowElseIf: false`
+- [no-empty-function](https://eslint.org/docs/rules/no-empty-function): `error, allow: arrowFunctions, functions, methods`
+- [no-empty-pattern](https://eslint.org/docs/rules/no-empty-pattern)
+- [no-eval](https://eslint.org/docs/rules/no-eval)
+- [no-extend-native](https://eslint.org/docs/rules/no-extend-native)
+- [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind)
+- [no-extra-label](https://eslint.org/docs/rules/no-extra-label)
+- [no-fallthrough](https://eslint.org/docs/rules/no-fallthrough)
+- [no-global-assign](https://eslint.org/docs/rules/no-global-assign): `error, exceptions:`
+- [no-implied-eval](https://eslint.org/docs/rules/no-implied-eval)
+- [no-iterator](https://eslint.org/docs/rules/no-iterator)
+- [no-labels](https://eslint.org/docs/rules/no-labels): `error, allowLoop: false, allowSwitch: false`
+- [no-lone-blocks](https://eslint.org/docs/rules/no-lone-blocks)
+- [no-loop-func](https://eslint.org/docs/rules/no-loop-func)
+- [no-multi-str](https://eslint.org/docs/rules/no-multi-str)
+- [no-new](https://eslint.org/docs/rules/no-new)
+- [no-new-func](https://eslint.org/docs/rules/no-new-func)
+- [no-new-wrappers](https://eslint.org/docs/rules/no-new-wrappers)
+- [no-octal](https://eslint.org/docs/rules/no-octal)
+- [no-octal-escape](https://eslint.org/docs/rules/no-octal-escape)
+- [no-proto](https://eslint.org/docs/rules/no-proto)
+- [no-redeclare](https://eslint.org/docs/rules/no-redeclare)
+- [no-restricted-properties](https://eslint.org/docs/rules/no-restricted-properties): `error, object: arguments, property: callee, message: argumen…`
+- [no-return-assign](https://eslint.org/docs/rules/no-return-assign): `error, always`
+- [no-return-await](https://eslint.org/docs/rules/no-return-await)
+- [no-script-url](https://eslint.org/docs/rules/no-script-url)
+- [no-self-assign](https://eslint.org/docs/rules/no-self-assign): `error, props: true`
+- [no-self-compare](https://eslint.org/docs/rules/no-self-compare)
+- [no-sequences](https://eslint.org/docs/rules/no-sequences)
+- [no-throw-literal](https://eslint.org/docs/rules/no-throw-literal)
+- [no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions): `error, allowShortCircuit: false, allowTernary: false, allowT…`
+- [no-unused-labels](https://eslint.org/docs/rules/no-unused-labels)
+- [no-useless-catch](https://eslint.org/docs/rules/no-useless-catch)
+- [no-useless-concat](https://eslint.org/docs/rules/no-useless-concat)
+- [no-useless-escape](https://eslint.org/docs/rules/no-useless-escape)
+- [no-useless-return](https://eslint.org/docs/rules/no-useless-return)
+- [no-void](https://eslint.org/docs/rules/no-void)
+- [no-with](https://eslint.org/docs/rules/no-with)
+- [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors): `error, allowEmptyReject: true`
+- [radix](https://eslint.org/docs/rules/radix)
+- [vars-on-top](https://eslint.org/docs/rules/vars-on-top)
+- [yoda](https://eslint.org/docs/rules/yoda)
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-torchbox",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-torchbox",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shareable ESLint config following Torchbox’s code style",
   "license": "MIT",
   "author": "Torchbox Ltd",


### PR DESCRIPTION
### Features

- Update to ESLint v6 and eslint-config-airbnb v18, significantly changing rules that are applied with this config ([#4](https://github.com/torchbox/eslint-config-torchbox/issues/4), [#10](https://github.com/torchbox/eslint-config-torchbox/pull/10)).
- Include rules for the React [Rules of hooks](https://reactjs.org/docs/hooks-rules.html) ([#3](https://github.com/torchbox/eslint-config-torchbox/issues/3), [#10](https://github.com/torchbox/eslint-config-torchbox/pull/10)), from the airbnb config update.
- Automatically detect which version of React is being used on the project to lint accordingly (part of the airbnb config update) ([#10](https://github.com/torchbox/eslint-config-torchbox/pull/10)).

### BREAKING CHANGES

This release updates most of the dependencies of the config:

| package                   | from    | to      |
| ------------------------- | ------- | ------- |
| eslint                    | ^5.0.0  | ^6.0.0  |
| eslint-config-airbnb      | ^17.1.0 | ^18.0.0 |
| eslint-plugin-react       | ^7.14.0 | ^7.16.0 |
| eslint-plugin-react-hooks | N/A     | ^1.7.0  |

To update, use `npx install-peerdeps --dev eslint-config-torchbox@latest` so all other peerDependencies are updated as well.

---

Additionally, this config now requires `react` to be defined as a dependency on the project. Please refer to our [React configuration instructions](https://github.com/torchbox/eslint-config-torchbox#react) if you wish to bypass this.
